### PR TITLE
Moved some methods in the AzDoPipeline class

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,18 @@ The properties file is located in src/main/resources. It contains the properties
 * __build.api.poll.timeout__ - The timeout value of polling the result of the pipeline run. If the final result is not retrieved yet, the polling stops after a number of seconds, defined by  __build.api.poll.timeout__.
 * __project.api__ - Name of the Azure DevOps base Project API; do not change this value.
 * __project.api.version__ - Version of the Azure DevOps Project API; only change if it is really needed (e.g., if a new version of the API is released).
+* __variable.groups.api__ - The Azure DevOps API used to retrieve the list of variable groups in the project.
+* __variable.groups.api.version__ - Version of this API.
+* __variable.groups.validate__ - Defines whether the variable groups in the YAML files must be validated. Default is true.
+* __environments.api__ - The Azure DevOps API used to retrieve the list of environments in the project.
+* __environments.api.version__ - Version of this API.
+* __environments.validate__ - Defines whether the environments in the YAML files must be validated. Default is true.
 * __error.continue__ - If _true_, the junit-.pipeline framework continues after an error is detected
   (e.g., if the pipeline YAML file or a template file is incorrect). Note, that this can result in unpredictable results.
   If _false_, the framework stops with the test as soon as an error is detected.
+* __templates.external.include__ - If true (= default), templates of other repositories are als included. This means that if a
+  method is executed, for example to skip a step, this also applies to these templates. If set to false, the templates in other
+  repositories are just as-is.
 > The property file is stored in the _resources_ folder.
 
 <br></br>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.hvmerode</groupId>
     <artifactId>junit-pipeline</artifactId>
-    <version>1.2.12</version>
+    <version>1.2.13</version>
 
     <name>junit-pipeline</name>
     <description>Perform unit- and integration tests with Azure DevOps pipelines.</description>

--- a/src/main/java/azdo/action/ActionAddPropertyToSection.java
+++ b/src/main/java/azdo/action/ActionAddPropertyToSection.java
@@ -1,0 +1,99 @@
+package azdo.action;
+
+import azdo.utils.Log;
+import azdo.yaml.ActionResult;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+/******************************************************************************************
+ This class is typically used to add a new property to a section.
+ It searches a section using a 'sectionType' and optionally a sectionIdentification, which
+ can be "" or null.
+ If the section is found, a property is added to the section.
+ There is no validation whether the property is valid.
+ ******************************************************************************************/
+public class ActionAddPropertyToSection implements Action {
+    private static final Log logger = Log.getLogger();
+    private String sectionType; // Is "@Bash03", for example
+    private String sectionIdentifier; // Optional identification of the section type
+    private String property; // The property of the section, for example "enabled"
+    private String propertyValue; // The value of the property, for example "true"
+
+    public ActionAddPropertyToSection(String sectionType,
+                                      String sectionIdentifier,
+                                      String property,
+                                      String propertyValue) {
+        this.sectionType = sectionType;
+        this.sectionIdentifier = sectionIdentifier;
+        this.property = property;
+        this.propertyValue = propertyValue;
+    }
+
+    public void execute (ActionResult actionResult) {
+        logger.debug("==> Method ActionAddPropertyToSection.execute");
+        logger.debug("actionResult.l1: {}", actionResult.l1);
+        logger.debug("actionResult.l2: {}", actionResult.l2);
+        logger.debug("actionResult.L3: {}", actionResult.l3);
+        logger.debug("sectionType: {}", sectionType);
+        logger.debug("sectionIdentifier: {}", sectionIdentifier);
+        logger.debug("property: {}", property);
+        logger.debug("propertyValue: {}", propertyValue);
+
+        if (actionResult.l3 == null) {
+            logger.debug("actionResult.l3 is null; return");
+        }
+
+        boolean foundSection = false;
+        if (actionResult.l3 instanceof ArrayList) {
+
+            // Run through the elements of the list and insert the section
+            ArrayList<Object> list = (ArrayList<Object>) actionResult.l3;
+            int index;
+            int size = list.size();
+            for (index = 0; index < size; index++) {
+                if (list.get(index) instanceof Map) {
+
+                    Map<String, Object> map = (Map<String, Object>) list.get(index);
+                    for (Map.Entry<String, Object> entry : map.entrySet()) {
+
+                        logger.debug("entry.getKey(): {}", entry.getKey());
+                        logger.debug("entry.getValue(): {}", entry.getValue());
+                        if (entry.getKey() instanceof String && sectionType.equals(entry.getKey())) {
+                            if (sectionIdentifier == null || sectionIdentifier.isEmpty()) {
+                                logger.debug("Found the section: {}", sectionType);
+                                foundSection = true;
+                            }
+                            else if (sectionIdentifier.equals(entry.getValue())) {
+                                logger.debug("Found the section: {}", sectionType);
+                                foundSection = true;
+                            }
+                        }
+                        if (foundSection) {
+                            // Add property to the section
+                            // This means updating the old one if it already exists, or adding the new one if not present.
+                            if (property != null && propertyValue != null && !property.isEmpty() && !propertyValue.isEmpty()) {
+                                if (map.containsKey(property))
+                                    map.replace(property, propertyValue);
+                                else
+                                    map.put(property, propertyValue);
+                            }
+                            actionResult.actionExecuted = true;
+                            return;
+                        }
+                    }
+                }
+                foundSection = false;
+            }
+        }
+        return;
+    }
+
+    // This action can be executed if only the appropriate section type is found
+    public boolean needsSectionIdentifier() {
+        return false;
+    }
+
+    // This action is not a custom action
+    public boolean isCustomAction () { return false; }
+}

--- a/src/main/java/azdo/utils/PropertyUtils.java
+++ b/src/main/java/azdo/utils/PropertyUtils.java
@@ -57,8 +57,10 @@ public class PropertyUtils {
     // Azure DevOps API: Distributed tasks
     private String variableGroupsApi = "/distributedtask/variablegroups";
     private String variableGroupsApiVersion = "api-version=7.0";
+    private boolean variableGroupsValidate = true;
     private String environmentsApi = "/distributedtask/environments";
     private String environmentsApiVersion = "api-version=7.0";
+    private boolean environmentsValidate = true;
 
     // Miscellaneous
     private String commitPattern;
@@ -129,8 +131,10 @@ public class PropertyUtils {
             // Azure DevOps Distributed task APIs
             variableGroupsApi = getStringProperty(properties, "variable.groups.api", variableGroupsApi);
             variableGroupsApiVersion = getStringProperty(properties, "variable.groups.api.version", variableGroupsApiVersion);
+            variableGroupsValidate = getBooleanProperty(properties, "variable.groups.validate", variableGroupsValidate);
             environmentsApi = getStringProperty(properties, "environments.api", environmentsApi);
             environmentsApiVersion = getStringProperty(properties, "environments.api.version", environmentsApiVersion);
+            environmentsValidate = getBooleanProperty(properties, "environments.validate", environmentsValidate);
 
             // Miscellaneous
             continueOnError = getBooleanProperty(properties, "error.continue", continueOnError);
@@ -371,6 +375,13 @@ public class PropertyUtils {
         return variableGroupsApiVersion;
     }
 
+    public void setVariableGroupsValidate(boolean variableGroupsValidate) {
+        this.variableGroupsValidate = variableGroupsValidate;
+    }
+    public boolean isVariableGroupsValidate() {
+        return variableGroupsValidate;
+    }
+
     public void setEnvironmentsApi(String environmentsApi) {
         this.environmentsApi = environmentsApi;
     }
@@ -382,6 +393,14 @@ public class PropertyUtils {
     public String getEnvironmentsApiVersion () {
         return environmentsApiVersion;
     }
+
+    public void setEnvironmentsValidate(boolean environmentsValidate) {
+        this.environmentsValidate = environmentsValidate;
+    }
+    public boolean isEnvironmentsValidate() {
+        return environmentsValidate;
+    }
+
 
     // Miscellaneous
     public void setCommitPattern (String commitPattern) {

--- a/src/main/java/azdo/yaml/YamlDocument.java
+++ b/src/main/java/azdo/yaml/YamlDocument.java
@@ -13,6 +13,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 import static azdo.utils.Constants.*;
@@ -235,14 +236,16 @@ public class YamlDocument {
         /******************************************************************************************
                        1. Validate whether a variable group (or more) exist
          ******************************************************************************************/
-        // Retrieve the list with variable groups and validate whether the are defined in the Azure DevOps project
-        ActionReturnPropertyValue actionReturnVariableGroups = new ActionReturnPropertyValue(SECTION_VARIABLES, PROPERTY_VARIABLE_GROUP);
-        performAction (actionReturnVariableGroups, SECTION_VARIABLES, "");
-        validatePropertyList (actionReturnVariableGroups.getPropertyValues(),
-                validVariableGroups,
-                project,
-                "Variable group",
-                continueOnError);
+        // Retrieve the list with variable groups and validate whether they are defined in the Azure DevOps project
+        if (validVariableGroups != null && !validVariableGroups.isEmpty()) {
+            ActionReturnPropertyValue actionReturnVariableGroups = new ActionReturnPropertyValue(SECTION_VARIABLES, PROPERTY_VARIABLE_GROUP);
+            performAction(actionReturnVariableGroups, SECTION_VARIABLES, "");
+            validatePropertyList(actionReturnVariableGroups.getPropertyValues(),
+                    validVariableGroups,
+                    project,
+                    "Variable group",
+                    continueOnError);
+        }
 
         /******************************************************************************************
              2. Validate the output files to determine whether it contains valid pipeline code
@@ -269,13 +272,15 @@ public class YamlDocument {
                             3. Validate whether an Environment (or more) exists.
          ******************************************************************************************/
         // Retrieve the list with environments and validate whether the are defined in the Azure DevOps project
-        ActionReturnPropertyValue actionReturnEnvironments = new ActionReturnPropertyValue(SECTION_JOBS, PROPERTY_ENVIRONMENT);
-        performAction (actionReturnEnvironments, SECTION_JOBS, "");
-        validatePropertyList (actionReturnEnvironments.getPropertyValues(),
-                validEnvironments,
-                project,
-                "Environment",
-                continueOnError);
+        if (validEnvironments != null && !validEnvironments.isEmpty()) {
+            ActionReturnPropertyValue actionReturnEnvironments = new ActionReturnPropertyValue(SECTION_JOBS, PROPERTY_ENVIRONMENT);
+            performAction(actionReturnEnvironments, SECTION_JOBS, "");
+            validatePropertyList(actionReturnEnvironments.getPropertyValues(),
+                    validEnvironments,
+                    project,
+                    "Environment",
+                    continueOnError);
+        }
     }
 
     /******************************************************************************************
@@ -463,9 +468,8 @@ public class YamlDocument {
 
         // Run through the YAML file and adjust the map
         boolean found = false;
-        for (Map.Entry<String, Object> entry : map.entrySet()) {
-            logger.debug("Key: {}", entry.getKey());
-            logger.debug("Value: {}", entry.getValue());
+        for(Iterator<Map.Entry<String, Object>> it = map.entrySet().iterator(); it.hasNext(); ) {
+            Map.Entry<String, Object> entry = it.next();
 
             if ("repository".equals(entry.getKey())) {
                 logger.debug("Found a repository");
@@ -482,13 +486,15 @@ public class YamlDocument {
 
             if (found) {
                 if ("type".equals(entry.getKey())) {
-                    entry.setValue("git"); // Make it always am Azure DeVOps Git project
+                    entry.setValue("git"); // Make it always a Azure DeVOps Git project
                 }
                 if ("endpoint".equals(entry.getKey())) {
-                    map.remove(entry.getKey()); // Don't use this for local repositories
+                    //map.remove(entry.getKey()); // Don't use this for local repositories
+                    it.remove();
                 }
                 if ("ref".equals(entry.getKey())) {
-                    map.remove(entry.getKey()); // Always use the default, which is 'refs/heads/main'
+                    //map.remove(entry.getKey()); // Always use the default, which is 'refs/heads/main'
+                    it.remove();
                 }
                 if ("name".equals(entry.getKey())) {
                     String name  = entry.getValue().toString();

--- a/src/main/resources/junit_pipeline.properties
+++ b/src/main/resources/junit_pipeline.properties
@@ -78,8 +78,10 @@ project.api.version=api-version=7.0
 ########################################################################################################################
 variable.groups.api=/distributedtask/variablegroups
 variable.groups.api.version=api-version=7.0
+variable.groups.validate=true
 environments.api=/distributedtask/environments
 environments.api.version=api-version=7.0
+environments.validate=true
 
 # The frequency to retrieve the build result and status using the API (in seconds)
 build.api.poll.frequency=10


### PR DESCRIPTION
Add option to add a property to a section
Checks on valid variable groups and valid environments are optional. This because in some cases the declared group contains a parameter or variable, which is not recognized when the yaml file is pre-compiled. Added properties (variable groups, environments) to README.md Latest version is 1.2.13